### PR TITLE
Lock in problematic dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,10 +46,10 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
   gem 'rspec-benchmark'
-  gem 'factory_bot_rails'
+  gem 'factory_bot_rails', '~> 4.8.2'
   gem 'pry-byebug'
   # Use sqlite3 as the database for Active Record
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 group :development do


### PR DESCRIPTION
Locks down two dependencies that were causing rake problems with setting up the db. Both of these are just band-aids to get project setup working for the time being. I did not commit `Gemfile.lock` since I had other local changes that I didn't want to introduce with this commit.

Sets `sqlite3` version to `1.3.6` due to ActiveRecord issue (See https://stackoverflow.com/questions/54527277/cant-activate-sqlite3-1-3-6-already-activated-sqlite3-1-4-0/54529016#54529016).

Sets `factory_bot_rails` version to `4.8.2` due to error `NoMethodError: undefined method 'email' in 'user' factory` (See https://github.com/thoughtbot/factory_bot_rails/issues/313)